### PR TITLE
Avoid changing the DOM if not necessary

### DIFF
--- a/src/elastic.directive.ts
+++ b/src/elastic.directive.ts
@@ -25,7 +25,7 @@ export class ElasticDirective {
     Observable.fromEvent(window, 'resize')
       .debounceTime(250)
       .distinctUntilChanged((evt:any) => evt.timeStamp)
-      .subscribe(() => this.adjust());
+      .subscribe(() => this.adjust(true));
   }
 
   ngAfterViewInit() {
@@ -46,15 +46,17 @@ export class ElasticDirective {
 
   @HostListener('input')
   onInput(): void {
-    this.adjust();
+    this.adjust(true);
   }
 
   ngAfterViewChecked(): void {
-    this.adjust();
+    this.adjust(false);
   }
 
-  adjust(): void {
-    this.textareaEl.style.height = 'auto';
-    this.textareaEl.style.height = this.textareaEl.scrollHeight + "px";
+  adjust(force: boolean): void {
+    if (force || this.textareaEl.style.height !== `${this.textareaEl.scrollHeight}px`) {
+      this.textareaEl.style.height = 'auto';
+      this.textareaEl.style.height = this.textareaEl.scrollHeight + "px";
+    }
   }
 }


### PR DESCRIPTION
When the textarea's height gets bigger than the viewport's height, if you scroll past the textarea and then try to scroll back up, Chrome won't let you scroll because we keep changing the actual height of the textarea beyond what we can see (ngAfterViewChecked triggers a lot!!). So I'm suggesting we only run the code that's in the `adjust` method if the scrollHeight has actually changed (for ngAfterViewChecked triggered calls)