### PR TITLE
rxjs import change

### DIFF
--- a/src/elastic.directive.ts
+++ b/src/elastic.directive.ts
@@ -1,6 +1,9 @@
 import { ElementRef, HostListener, Directive, AfterViewInit, Optional, OnInit, OnDestroy, NgZone } from '@angular/core';
 import { NgModel } from '@angular/forms';
-import { Observable, Subscription } from 'rxjs/Rx';
+import 'rxjs/add/observable/fromEvent';
+import 'rxjs/add/operator/debounceTime';
+import { Observable } from 'rxjs/Observable';
+import { Subscription } from 'rxjs/Subscription';
 
 @Directive({
   selector: '[fz-elastic]'


### PR DESCRIPTION
I can't build my Ionic application without this small change.

Ionic-angular has upgraded to 3.9.2 which uses Angular 5 and RxJS 5.5, and the `--prod` build fails without this change.